### PR TITLE
Hide BatteryPill & Powerinfo if percentage > 0

### DIFF
--- a/users/Configs/quickshell/kurukurubar/Widgets/BatteryPill.qml
+++ b/users/Configs/quickshell/kurukurubar/Widgets/BatteryPill.qml
@@ -8,6 +8,7 @@ import "../Generics/" as Gen
 Rectangle {
   Layout.minimumWidth: batText.width + 20
   color: Dat.Colors.primary
+  visible: UPower.displayDevice.percentage > 0
 
   Behavior on Layout.minimumWidth {
     NumberAnimation {

--- a/users/Configs/quickshell/kurukurubar/Widgets/PowerInfo.qml
+++ b/users/Configs/quickshell/kurukurubar/Widgets/PowerInfo.qml
@@ -13,6 +13,7 @@ RowLayout {
     Layout.fillHeight: true
     Layout.fillWidth: true
     color: "transparent"
+    visible: UPower.displayDevice.percentage > 0
 
     Text {
       anchors.fill: parent
@@ -29,6 +30,7 @@ RowLayout {
     Layout.fillWidth: true
     Layout.preferredWidth: 2
     color: "transparent"
+    visible: UPower.displayDevice.percentage > 0
 
     Text {
       id: text
@@ -63,6 +65,7 @@ RowLayout {
     Layout.fillHeight: true
     Layout.fillWidth: true
     color: "transparent"
+    visible: UPower.displayDevice.percentage > 0
 
     Text {
       anchors.fill: parent


### PR DESCRIPTION
Added `visible: UPower.displayDevice.percentage > 0` to `BatteryPill.qml` (Line 11) and to `PowerInfo.qml` (Line 16) to hide the battery informations whenever the percentage is 0 which should only be the case for desktops (or fully empty batteries lol).