### PR TITLE
Revert "Qs: Notification: MouseArea now covers all of notification strip"

### DIFF
--- a/users/Configs/quickshell/kurukurubar/Generics/Notification.qml
+++ b/users/Configs/quickshell/kurukurubar/Generics/Notification.qml
@@ -28,7 +28,6 @@ Rectangle {
 
   MouseArea {
     id: dragArea
-    z: 1
 
     anchors.fill: parent
 
@@ -160,7 +159,6 @@ Rectangle {
 
           MouseArea {
             id: bodMArea
-            z: 1
 
             acceptedButtons: Qt.LeftButton
             anchors.fill: parent


### PR DESCRIPTION
Reverts Rexcrazy804/Zaphkiel#27

seems like the click action on the notification action fail to work