### PR TITLE
Update xvim.vivi

### DIFF
--- a/pkgs/nvim/config.nix
+++ b/pkgs/nvim/config.nix
@@ -35,7 +35,7 @@
         image-nvim
         catppuccin-nvim
         rose-pine
-        dracula-nvim
+        tokyonight-nvim
         neo-tree-nvim
         which-key-nvim
         toggleterm-nvim

--- a/pkgs/nvim/default.nix
+++ b/pkgs/nvim/default.nix
@@ -24,7 +24,7 @@ lib.fix (self: {
     initLua =
       prev.initLua
       + ''
-        vim.cmd.colorscheme "dracula"
+        vim.cmd.colorscheme "tokyonight-night"
       '';
   });
 })

--- a/users/dots/nvim/lua/lazy/fzf-lua.lua
+++ b/users/dots/nvim/lua/lazy/fzf-lua.lua
@@ -55,6 +55,8 @@ return {
   after = function()
     require("fzf-lua").setup({
       actions = { files = { ["enter"] = FzfLua.actions.file_edit } },
+      -- Force bg color to be transparent - Sumee
+      fzf_colors = { ["bg"] = "-1" },
     })
   end,
 }

--- a/users/dots/nvim/lua/lazy/themes.lua
+++ b/users/dots/nvim/lua/lazy/themes.lua
@@ -83,14 +83,24 @@ return {
     end,
   },
   {
-    "dracula.nvim",
-    colorscheme = { "dracula", "dracula-soft" },
+    "tokyonight.nvim",
+    colorscheme = {
+      "tokyonight",
+      "tokyonight-night",
+      "tokyonight-storm",
+      "tokyonight-day",
+      "tokyonight-moon",
+    },
     after = function()
-      local dracula = require("dracula")
-      dracula.setup({
-        transparent_bg = true,
-        italic_comment = true,
-        overrides = {},
+      require("tokyonight").setup({
+        transparent = true,
+        lualine_bold = true,
+        styles = { sidebars = "transparent", floats = "transparent" },
+        on_colors = function(colors) colors.bg_statusline = nil end,
+        on_highlights = function(hl, c)
+          hl.ColorColumn = { bg = c.none }
+          hl.TabLineFill = { bg = c.none }
+        end,
       })
     end,
   },


### PR DESCRIPTION
Due to dracula theme being the pain in the ass for making buffer line and lualine transparent, I'm making xvim.vivi to set tokyonight as the default colorscheme. 

This also fixes fzf-lua being buggy and not wanting to set file directory to be transparent.

- System Built: NixOS 25.11 Xantusia e643668
- System Tested on: Quartz
- Irminsul Verified?: Yes
- Preliminary discord discussions: Certainly Yes
- Background changed?: Yes, Hatsune Miku fits with the new xvim theme better imo.